### PR TITLE
added blackberry 10

### DIFF
--- a/lib/woothee/os.rb
+++ b/lib/woothee/os.rb
@@ -121,6 +121,11 @@ module Woothee::OS
       if ua =~ /BlackBerry(?:\d+)\/([.0-9]+) /
         os_version = $1
       end
+    when ua.index('BB10')
+      data = Woothee::DataSet.get('BlackBerry')
+      if ua =~ /BB10(?:.+)Version\/([.0-9]+)/
+        os_version = $1
+      end
     end
 
     if result[Woothee::KEY_NAME] && result[Woothee::KEY_NAME] == Woothee::DataSet.get('Firefox')[Woothee::KEY_NAME]


### PR DESCRIPTION
Addition of BlackBerry 10 user agent parsing in ruby.
Are all languages being managed separately?
Also, I cannot add a spec for this case to smartphone_misc.yaml, but obviously other languages projects will fail on it. How do you usually attack this problem?