### PR TITLE
Woothee.is_crawler should handle nil

### DIFF
--- a/lib/woothee.rb
+++ b/lib/woothee.rb
@@ -16,7 +16,7 @@ module Woothee
  end
 
   def self.is_crawler(useragent)
-    useragent.length > 0 and useragent != '-' and try_crawler(useragent, {})
+    !!useragent && useragent.length > 0 and useragent != '-' and try_crawler(useragent, {})
   end
 
   def self.exec_parse(useragent)

--- a/spec/02_run_testsets_spec.rb
+++ b/spec/02_run_testsets_spec.rb
@@ -26,11 +26,18 @@ describe Woothee do
   TARGETS.each do |filename,groupname|
     YAML.load_file(TESTSET_DIR + filename).each do |e|
       r = Woothee.parse(e['target'])
-      [:name, :category, :os, :version, :vendor, :os_version].each do |attribute|
-        it groupname + ("test(%s): %s" % [attribute, e['target']]) do
-          if [:name, :category].include?(attribute) or ([:os, :version, :vendor, :os_version].include?(attribute) and e.has_key?(attribute.to_s))
-            expect(r[attribute].to_s).to eql(e[attribute.to_s])
+      context groupname do
+        [:name, :category, :os, :version, :vendor, :os_version].each do |attribute|
+          it  ("test(%s): %s" % [attribute, e['target']]) do
+            if [:name, :category].include?(attribute) or ([:os, :version, :vendor, :os_version].include?(attribute) and e.has_key?(attribute.to_s))
+              expect(r[attribute].to_s).to eql(e[attribute.to_s])
+            end
           end
+        end
+
+        it "test(is_crawler): #{e['target']}" do
+          is_major_crawler = e['category'] == 'crawler' && e['name'] != 'misc crawler'
+          expect(Woothee.is_crawler(e['target'])).to eq(is_major_crawler)
         end
       end
     end


### PR DESCRIPTION
`Woothee.is_crawler` fails when passed nil.

```
[1] pry(main)> Woothee.is_crawler(nil)
NoMethodError: undefined method `length' for nil:NilClass
from <snip>/gems/woothee-1.1.0/lib/woothee.rb:19:in `is_crawler'
```