### PR TITLE
warning: mismatched indentations at 'end' with 'def' at 14

### DIFF
--- a/lib/woothee.rb
+++ b/lib/woothee.rb
@@ -13,7 +13,7 @@ require 'woothee/version'
 module Woothee
   def self.parse(useragent)
     fill_result(exec_parse(useragent))
- end
+  end
 
   def self.is_crawler(useragent)
     !!useragent && useragent.length > 0 and useragent != '-' and try_crawler(useragent, {})


### PR DESCRIPTION
This patch fixes a Ruby :warning:.