### PR TITLE
for Android 9

### DIFF
--- a/lib/woothee/os.rb
+++ b/lib/woothee/os.rb
@@ -89,7 +89,7 @@ module Woothee::OS
     os_version = nil
     if ua.index('Android')
       data = Woothee::DataSet.get('Android')
-      if ua =~ /Android[- ](\d+\.\d+(?:\.\d+)?)/
+      if ua =~ /Android[- ](\d+\.*\d*(?:\.\d+)?)/
         os_version = $1
       end
     else


### PR DESCRIPTION
When the version of the Android OS reaches 9, there seems to be one in which the OS version of User Agent is '9' instead of '9.0'.
Android 9.0 => Android 9

