### PR TITLE
remove debug statement

### DIFF
--- a/lib/woothee/browser.rb
+++ b/lib/woothee/browser.rb
@@ -77,7 +77,6 @@ module Woothee::Browser
     # Google Search App
     if ua =~ /GSA\/([.0-9]+)/o
       version = $1
-      p(dataset: Woothee::DataSet.get("GSA"), version: version)
       update_map(result, Woothee::DataSet.get("GSA"))
       update_version(result, version)
       return true


### PR DESCRIPTION
The recent release introduced a lot of log output in our fluentd instances. This PR simply removes the debug statement.